### PR TITLE
set correct length when initialising an intbv with a binary string containing underscores

### DIFF
--- a/myhdl/_intbv.py
+++ b/myhdl/_intbv.py
@@ -53,7 +53,7 @@ class intbv(object):
         elif isinstance(val, StringType):
             mval = val.replace('_', '')
             self._val = long(mval, 2)
-            _nrbits = len(val)
+            _nrbits = len(mval)
         elif isinstance(val, intbv):
             self._val = val._val
             self._min = val._min


### PR DESCRIPTION
Something that caught my eye when I was working on code to initialise an intbv with a text string