### PR TITLE
Cosim cmdline

### DIFF
--- a/doc/source/manual/reference.rst
+++ b/doc/source/manual/reference.rst
@@ -647,8 +647,13 @@ MyHDL
 
    Class to construct a new Cosimulation object.
 
-   The *exe* argument is a command string to execute an HDL simulation. The
-   *kwargs* keyword arguments provide a named association between signals (regs &
+   The *exe* argument is the command to execute an HDL simulation, which can be
+   either a string of the entire command line or a list of strings.
+   In the latter case, the first element is the executable, and subsequent elements
+   are program arguments. Providing a list of arguments allows Python to correctly
+   handle spaces or other characters in program arguments.
+
+   The *kwargs* keyword arguments provide a named association between signals (regs &
    nets) in the HDL simulator and signals in the MyHDL simulator. Each keyword
    should be a name listed in a ``$to_myhdl`` or ``$from_myhdl`` call in the HDL
    code. Each argument should be a :class:`Signal` declared in the MyHDL code.

--- a/myhdl/_Cosimulation.py
+++ b/myhdl/_Cosimulation.py
@@ -72,7 +72,8 @@ class Cosimulation(object):
             os.close(wf)
             os.environ['MYHDL_TO_PIPE'] = str(wt)
             os.environ['MYHDL_FROM_PIPE'] = str(rf)
-            arglist = exe.split()
+            if isinstance(exe, list): arglist = exe
+            else: arglist = exe.split()
             p = arglist[0]
             arglist[0] = os.path.basename(p)
             try:

--- a/myhdl/test/conversion/toVerilog/util.py
+++ b/myhdl/test/conversion/toVerilog/util.py
@@ -1,6 +1,6 @@
 import os
 path = os.path
-
+import subprocess
 from myhdl import *
 
 # Icarus
@@ -9,9 +9,9 @@ def setupCosimulationIcarus(**kwargs):
     objfile = "%s.o" % name
     if path.exists(objfile):
         os.remove(objfile)
-    analyze_cmd = "iverilog -o %s %s.v tb_%s.v" % (objfile, name, name)
-    os.system(analyze_cmd)
-    simulate_cmd = "vvp -m ../../../../cosimulation/icarus/myhdl.vpi %s" % objfile
+    analyze_cmd = ['iverilog', '-o', objfile, '%s.v' %name, 'tb_%s.v' % name]
+    subprocess.call(analyze_cmd)
+    simulate_cmd = ['vvp', '-m', '../../../../cosimulation/icarus/myhdl.vpi', objfile]
     return Cosimulation(simulate_cmd, **kwargs)
 
 # cver


### PR DESCRIPTION
Some times cosimulation command lines contains spaces, semi-colon and others. In theses cases, it is necessary to pass arguments as a list. This branch implements this in Cosimulation(exe, ...).