### PR TITLE
toVHDL.directory should also set where the package file is placed

### DIFF
--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -143,7 +143,7 @@ class _ToVHDLConvertor(object):
 
         vpath = os.path.join(directory, name + ".vhd")
         vfile = open(vpath, 'w')
-        ppath = "pck_myhdl_%s.vhd" % _shortversion
+        ppath = os.path.join(directory, "pck_myhdl_%s.vhd" % _shortversion)
         pfile = None
 #        # write MyHDL package always during development, as it may change
 #        pfile = None

--- a/myhdl/test/conversion/general/test_set_dir.py
+++ b/myhdl/test/conversion/general/test_set_dir.py
@@ -4,6 +4,10 @@ from myhdl import *
 from tempfile import mkdtemp
 from shutil import rmtree
 
+import myhdl
+_version = myhdl.__version__.replace('.','')
+_shortversion = _version.replace('dev','')
+
 def simple_dir_model(din, dout, clk):
     """ Simple convertible model """
 
@@ -36,6 +40,30 @@ def test_toVHDL_set_dir():
         toVHDL.directory = None        
         rmtree(tmp_dir)
 
+def test_toVHDL_myhdl_package_set_dir():
+    '''In order that the MyHDL package files are located in the 
+    same place as the generated VHDL files, when the directory attribute of 
+    toVHDL is set, this location should be used for the generated MyHDL 
+    package files.
+    '''
+    tmp_dir = mkdtemp()
+
+    din = Signal(intbv(0)[5:])
+    dout = Signal(intbv(0)[5:])
+    clock = Signal(bool(0))
+
+    try:
+        toVHDL.directory = tmp_dir
+        toVHDL(simple_dir_model, din, dout, clock)
+
+        assert os.path.exists(
+            os.path.join(tmp_dir, "pck_myhdl_%s.vhd" % _shortversion))
+
+    finally:
+
+        toVHDL.directory = None
+
+        rmtree(tmp_dir)
 
 def test_toVerilog_set_dir():
     '''In order that a developer can define where in the project 
@@ -62,6 +90,7 @@ def test_toVerilog_set_dir():
         toVerilog.directory = None
         toVerilog.no_testbench = no_testbench_state
         rmtree(tmp_dir)
+
 
 def test_toVerilog_testbench_set_dir():
     '''In order that generated Verilog test bench files are located in the 


### PR DESCRIPTION
I made an omission in the original toV* directory attribute work in missing the changing the path of the myhdl VHDL package file.

This patch fixes that, along with a test.