### PR TITLE
conv: allow modifying bits of signals inside lists

### DIFF
--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -776,6 +776,10 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
         node.obj = self.getObj(node.value)
 
     def getAttr(self, node):
+        if isinstance(node.value, ast.Subscript):
+            self.setAttr(node)
+            return
+
         assert isinstance(node.value, ast.Name), node.value
         n = node.value.id
         if n in self.tree.symdict:

--- a/myhdl/conversion/_toVerilog.py
+++ b/myhdl/conversion/_toVerilog.py
@@ -603,6 +603,10 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
         self.visit(node.value)
 
     def getAttr(self, node):
+        if isinstance(node.value, ast.Subscript):
+            self.setAttr(node)
+            return
+
         assert isinstance(node.value, ast.Name), node.value
         n = node.value.id
         if n in self.tree.symdict:


### PR DESCRIPTION
This commit fixes conversion breaking while modifying bits of signal
inside list.
example: somelist[i].next[j] = something

This PR is also for confirming that travis works on PRs.