### PR TITLE
VCD dump of tristate signals

### DIFF
--- a/myhdl/_Signal.py
+++ b/myhdl/_Signal.py
@@ -302,13 +302,22 @@ class _Signal(object):
         print("s%s %s" % (str(self._val), self._code), file=sim._tf)
         
     def _printVcdHex(self):
-        print("s%s %s" % (hex(self._val), self._code), file=sim._tf)
+        if self._val is None:
+            print("sz %s" % self._code, file=sim._tf)
+        else:
+            print("s%s %s" % (hex(self._val), self._code), file=sim._tf)
 
     def _printVcdBit(self):
-        print("%d%s" % (self._val, self._code), file=sim._tf)
+        if self._val is None:
+            print("z%s" % self._code, file=sim._tf)
+        else:
+            print("%d%s" % (self._val, self._code), file=sim._tf)
 
     def _printVcdVec(self):
-        print("b%s %s" % (bin(self._val, self._nrbits), self._code), file=sim._tf)
+        if self._val is None:
+            print("b%s %s" % ('z'*self._nrbits, self._code), file=sim._tf)
+        else:
+            print("b%s %s" % (bin(self._val, self._nrbits), self._code), file=sim._tf)
 
     ### use call interface for shadow signals ###
     def __call__(self, left, right=None):

--- a/myhdl/_traceSignals.py
+++ b/myhdl/_traceSignals.py
@@ -35,6 +35,7 @@ import shutil
 from myhdl import _simulator, __version__, EnumItemType
 from myhdl._extractHierarchy import _HierExtr
 from myhdl import TraceSignalsError
+from myhdl._ShadowSignal import _TristateSignal, _TristateDriver
 
 _tracing = 0
 _profileFunc = None
@@ -148,7 +149,14 @@ def _writeVcdSigs(f, hierarchy, tracelists):
                 print("$upscope $end", file=f)
         print("$scope module %s $end" % name, file=f)
         for n, s in sigdict.items():
-            if s._val is None:
+            if isinstance(s, _TristateSignal):
+                seffval = s._orival
+            elif isinstance(s, _TristateDriver):
+                seffval = s._sig._orival
+            else:
+                seffval = s._val
+
+            if seffval is None:
                 raise ValueError("%s of module %s has no initial value" % (n, name))
             if not s._tracing:
                 s._tracing = 1
@@ -156,7 +164,7 @@ def _writeVcdSigs(f, hierarchy, tracelists):
                 siglist.append(s)
             w = s._nrbits
             # use real for enum strings
-            if w and not isinstance(s._val, EnumItemType):
+            if w and not isinstance(seffval, EnumItemType):
                 if w == 1:
                     print("$var reg 1 %s %s $end" % (s._code, n), file=f)
                 else:
@@ -170,7 +178,14 @@ def _writeVcdSigs(f, hierarchy, tracelists):
             for n in memdict.keys():
                 memindex = 0
                 for s in memdict[n].mem:
-                    if s._val is None:
+                    if isinstance(s, _TristateSignal):
+                        seffval = s._orival
+                    elif isinstance(s, _TristateDriver):
+                        seffval = s._sig._orival
+                    else:
+                        seffval = s._val
+
+                    if seffval is None:
                         raise ValueError("%s of module %s has no initial value" % (n, name))
                     if not s._tracing:
                         s._tracing = 1

--- a/myhdl/test/core/test_traceSignals.py
+++ b/myhdl/test/core/test_traceSignals.py
@@ -33,7 +33,7 @@ from unittest import TestCase
 import shutil
 import glob
 
-from myhdl import delay, Signal, Simulation, _simulator, instance
+from myhdl import delay, intbv, Signal, Simulation, _simulator, instance
 from myhdl._traceSignals import traceSignals, TraceSignalsError, _error
 
 QUIET=1
@@ -72,7 +72,42 @@ def top3():
     return inst_1, inst_2
 
 
+def genTristate(clk, x, y, z):
+    xd = x.driver()
+    yd = y.driver()
+    zd = z.driver()
 
+    @instance
+    def ckgen():
+        while 1:
+            yield delay(10)
+            clk.next = not clk
+    @instance
+    def logic():
+        for v in [True, False, None, 0, True, None, None, 1]:
+            yield clk.posedge
+            xd.next = v
+            if v is None:
+                yd.next = zd.next = None
+            elif v:
+                yd.next = zd.next = 11
+            else:
+                yd.next = zd.next = 0
+    return ckgen,logic
+
+def tristate():
+    from myhdl import TristateSignal
+    clk = Signal(bool(0))
+    x = TristateSignal(True)            # single bit
+    y = TristateSignal(intbv(0))        # intbv with undefined width
+    z = TristateSignal(intbv(0)[8:])    # intbv with fixed width
+
+    inst = genTristate(clk, x, y, z)
+    return inst
+
+def topTristate():
+    inst = traceSignals(tristate)
+    return inst
 
 class TestTraceSigs(TestCase):
 
@@ -86,8 +121,8 @@ class TestTraceSigs(TestCase):
         if _simulator._tracing:
             _simulator._tf.close()
             _simulator._tracing = 0
-        for p in paths:
-            os.remove(p)
+        #for p in paths:
+        #    os.remove(p)
 
 ##     def testTopName(self):
 ##         p = "dut.vcd"
@@ -138,6 +173,9 @@ class TestTraceSigs(TestCase):
         dut = traceSignals(top)
         self.assertTrue(path.exists(pdut))
         self.assertTrue(not path.exists(psub))
+
+    def testTristateTrace(self):
+        Simulation(topTristate()).run(100, quiet=QUIET)
 
     def testBackupOutputFile(self):
         p = "%s.vcd" % fun.__name__


### PR DESCRIPTION
Due to pull request #21, which fixes issue #19, TristateSignals may contain 'None' value when we dump it to .vcd file. This PR writes 'z' to .vcd if it sees 'None' value.