### PR TITLE
Assign initial zero values to standard data types

### DIFF
--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -387,9 +387,13 @@ def _writeSigDecls(f, intf, siglist, memlist):
                 warnings.warn("%s: %s" % (_error.UnreadSignal, s._name),
                               category=ToVHDLWarning
                               )
-            # the following line implements initial value assignments
-            # print >> f, "%s %s%s = %s;" % (s._driven, r, s._name, int(s._val))
-            print("signal %s: %s%s;" % (s._name, p, r), file=f)
+            # Initial zero value assignments
+            if p in ['signed', 'unsigned', 'std_logic_vector']:
+                print("signal %s: %s%s := (others => '0');" % (s._name, p, r), file=f)
+            elif p == 'std_logic':
+                print("signal %s: %s%s := '0';" % (s._name, p, r), file=f)
+            else:
+                print("signal %s: %s%s;" % (s._name, p, r), file=f)
         elif s._read:
             # the original exception
             # raise ToVHDLError(_error.UndrivenSignal, s._name)


### PR DESCRIPTION
Initializing signals at least with zero values is considered a good practice in C/C++. My experience points the same truth is applicable to VHDL.

See also
 http://stackoverflow.com/questions/6363130/is-there-a-reason-to-initialize-not-reset-signals-in-vhdl-and-verilog
 http://stackoverflow.com/questions/16814653/vhdl-signal-initialisation