### PR TITLE
A new simulation instance clears the signal state.

### DIFF
--- a/myhdl/_Simulation.py
+++ b/myhdl/_Simulation.py
@@ -70,6 +70,11 @@ class Simulation(object):
         self._finished = False
         del _futureEvents[:]
         del _siglist[:]
+
+        # We need to clear all the signals since we have a new simulation
+        # instance. This will break other simulation instances.
+        for s in _signals:
+            s._clear()
         
         
     def _finalize(self):


### PR DESCRIPTION
Consider this [gist](https://gist.github.com/hgomersall/3aa0fe0eaec408555a7d).

There is a distinct problem in which the two simulators step on each other due to the signal state from the first sim stepping on the toes of the second sim.

This PR clears the old simulation state when a new simulation instance is created.

