### PR TITLE
_toVHDL: Added correct tristate assignment for std_logic signal

### DIFF
--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -1276,7 +1276,10 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
             else:
                 s = "True"
         elif n == 'None':
-            s = "(others => 'Z')"
+            if node.vhd.size == 1:
+                s = "'Z'"
+            else:
+            	s = "(others => 'Z')"
         elif n in self.tree.vardict:
             s = n
             obj = self.tree.vardict[n]


### PR DESCRIPTION
When using a non-vector TrisTate the VHDL conversion generates am *(others => 'Z')* assignment, which for a std_logic signal is obviously wrong. E.g. the following source:
```python
def ts( clk, reset, tsenable, tson, tsout , readback ):

    outdriver = tsout.driver()

    @always_seq( clk.posedge, reset = reset )
    def rtlseq():
        if tsenable:
            if tson:
                outdriver.next = 1
            else:
                outdriver.next = 0
        else:
            outdriver.next = None

    @always_comb
    def rtlcomb():
        if tsout :
            readback.next = 1
        else:
            readback.next = 0

    return rtlseq, rtlcomb
```

gets the following VHDL:
```VHDL
entity ts is
	port(
		clk      : in    std_logic;
		reset    : in    std_logic;
		tsenable : in    std_logic;
		tson     : in    std_logic;
		tsout    : inout std_logic;
		readback : out   std_logic
	);
end entity ts;

architecture MyHDL of ts is
	signal outdriver : std_logic;

begin
	tsout <= outdriver;

	TS_RTLSEQ : process(clk, reset) is
	begin
		if (reset = '1') then
			outdriver <= '0';
		elsif rising_edge(clk) then
			if bool(tsenable) then
				if bool(tson) then
					outdriver <= '1';
				else
					outdriver <= '0';
				end if;
			else
				outdriver <= (others => 'Z');
			end if;
		end if;
	end process TS_RTLSEQ;

	TS_RTLCOMB : process(tsout) is
	begin
		if bool(tsout) then
			readback <= '1';
		else
			readback <= '0';
		end if;
	end process TS_RTLCOMB;

end architecture MyHDL;
```
the _(others => 'Z')_ has to be replaced by a single _'Z'_