### PR TITLE
replaced call to built-in 'bin' function with call to 'bin' function from _bin.py

### DIFF
--- a/myhdl/_ShadowSignal.py
+++ b/myhdl/_ShadowSignal.py
@@ -200,8 +200,8 @@ class ConcatSignal(_ShadowSignal):
             if w == 1:
                 if isinstance(a, _Signal):
                     if isinstance(a, bool):
-                     lines.append("%s(%s) <= %s;" % (self._name, lo, a._name))
-                else:
+                        lines.append("%s(%s) <= %s;" % (self._name, lo, a._name))
+                    else:
                         lines.append("%s(%s) <= %s(0);" % (self._name, lo, a._name))
                 else:
                      lines.append("%s(%s) <= '%s';" % (self._name, lo, bin(ini[lo])))

--- a/myhdl/_ShadowSignal.py
+++ b/myhdl/_ShadowSignal.py
@@ -150,7 +150,7 @@ class ConcatSignal(_ShadowSignal):
                 raise TypeError("ConcatSignal: inappropriate argument type: %s" \
                                 % type(arg))
             nrbits += w
-            val = val << w | v & (long(1) << w)-1
+            val = val << w | v & (int(1) << w)-1
         self._initval = val
         ini = intbv(val)[nrbits:]
         _ShadowSignal.__init__(self, ini)

--- a/myhdl/_ShadowSignal.py
+++ b/myhdl/_ShadowSignal.py
@@ -148,7 +148,7 @@ class ConcatSignal(_ShadowSignal):
                 v = int(a, 2)
             else:
                 raise TypeError("ConcatSignal: inappropriate argument type: %s" \
-                                % type(arg))
+                                % type(a))
             nrbits += w
             val = val << w | v & (int(1) << w)-1
         self._initval = val
@@ -199,7 +199,7 @@ class ConcatSignal(_ShadowSignal):
             lo = hi - w
             if w == 1:
                 if isinstance(a, _Signal):
-                    if isinstance(a, bool):
+                    if a._type == bool:
                         lines.append("%s(%s) <= %s;" % (self._name, lo, a._name))
                     else:
                         lines.append("%s(%s) <= %s(0);" % (self._name, lo, a._name))
@@ -209,7 +209,7 @@ class ConcatSignal(_ShadowSignal):
                 if isinstance(a, _Signal):
                     lines.append("%s(%s-1 downto %s) <= %s;" % (self._name, hi, lo, a._name))
                 else:
-                    lines.append('%s(%s-1 downto %s) <= "%s";' % (self._name, hi, lo, bin(ini[hi:lo],w)))
+                    lines.append('%s(%s-1 downto %s) <= "%s";' % (self._name, hi, lo, bin(ini[hi:lo], w)))
             hi = lo
         return "\n".join(lines)
 
@@ -225,14 +225,17 @@ class ConcatSignal(_ShadowSignal):
             lo = hi - w
             if w == 1:
                 if isinstance(a, _Signal):
-                    lines.append("assign %s[%s] = %s;" % (self._name, lo, a._name))
+                    if a._type == bool:
+                        lines.append("assign %s[%s] = %s;" % (self._name, lo, a._name))
+                    else:
+                        lines.append("assign %s[%s] = %s[0];" % (self._name, lo, a._name))
                 else:
                     lines.append("assign %s[%s] = 'b%s;" % (self._name, lo, bin(ini[lo])))
             else:
                 if isinstance(a, _Signal):
                     lines.append("assign %s[%s-1:%s] = %s;" % (self._name, hi, lo, a._name))
                 else:
-                    lines.append("assign %s[%s-1:%s] = 'b%s;" % (self._name, hi, lo, bin(ini[hi:lo],w)))
+                    lines.append("assign %s[%s-1:%s] = 'b%s;" % (self._name, hi, lo, bin(ini[hi:lo], w)))
             hi = lo
         return "\n".join(lines)
 

--- a/myhdl/_ShadowSignal.py
+++ b/myhdl/_ShadowSignal.py
@@ -205,8 +205,7 @@ class ConcatSignal(_ShadowSignal):
             else:
                 if isinstance(a, _Signal): 
                     lines.append("%s(%s-1 downto %s) <= %s;" % (self._name, hi, lo, a._name))
-                else:
-                    lines.append('%s(%s-1 downto %s) <= "%s";' % (self._name, hi, lo, bin(ini[hi:lo],w)))
+                else:                    lines.append('%s(%s-1 downto %s) <= "%s";' % (self._name, hi, lo, bin(ini[hi:lo],w)))
             hi = lo
         return "\n".join(lines)
 
@@ -224,12 +223,12 @@ class ConcatSignal(_ShadowSignal):
                 if isinstance(a, _Signal): 
                     lines.append("assign %s[%s] = %s;" % (self._name, lo, a._name))
                 else:
-                    lines.append("assign %s[%s] = 'b%s;" % (self._name, lo, bin(ini[lo])))
+                    lines.append("assign %s[%s] = 'b%s;" % (self._name, lo, bin(ini[lo])[2:]))
             else:
                 if isinstance(a, _Signal): 
                     lines.append("assign %s[%s-1:%s] = %s;" % (self._name, hi, lo, a._name))
                 else:
-                    lines.append("assign %s[%s-1:%s] = 'b%s;" % (self._name, hi, lo, bin(ini[hi:lo],w)]))
+                    lines.append("assign %s[%s-1:%s] = 'b%s;" % (self._name, hi, lo, bin(ini[hi:lo])[2:]))
             hi = lo
         return "\n".join(lines)
 

--- a/myhdl/test/conversion/general/test_ShadowSignal.py
+++ b/myhdl/test/conversion/general/test_ShadowSignal.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import
 from myhdl import *
 
 def bench_SliceSignal():
-    
+
     s = Signal(intbv(0)[8:])
     a, b, c = s(7), s(5), s(0)
     d, e, f, g = s(8,5), s(6,3), s(8,0), s(4,3)
-    N = len(s) 
+    N = len(s)
 
     @instance
     def check():
@@ -29,12 +29,12 @@ def test_SliceSignal():
 
 
 def bench_ConcatSignal():
-    
+
     a = Signal(intbv(0)[5:])
     b = Signal(bool(0))
     c = Signal(intbv(0)[3:])
     d = Signal(intbv(0)[4:])
-    
+
     s = ConcatSignal(a, b, c, d)
 
     I_max = 2**len(a)
@@ -60,7 +60,7 @@ def test_ConcatSignal():
     assert conversion.verify(bench_ConcatSignal) == 0
 
 def bench_ConcatSignalWithConsts():
-    
+
     a = Signal(intbv(0)[5:])
     b = Signal(bool(0))
     c = Signal(intbv(0)[3:])
@@ -68,10 +68,12 @@ def bench_ConcatSignalWithConsts():
 
     c1 = "10"
     c2 = intbv(53)[3:]
+    c2a = intbv(53)[8:]
     c3 = '0'
     c4 = bool(1)
-  
-    s = ConcatSignal(c1, a, c2, b, c3, c, c4, d)
+    c5 = intbv(1)[1:]
+
+    s = ConcatSignal(c1, a, c2, c2a, b, c3, c, c4, d, c5)
 
     I_max = 2**len(a)
     J_max = 2**len(b)
@@ -124,7 +126,7 @@ def bench_TristateSignal():
         c.next = None
         yield delay(10)
         #print s
-    
+
     return check
 
 
@@ -136,9 +138,9 @@ def test_TristateSignal():
 def permute(x, a, mapping):
 
     p = [a(m) for m in mapping]
-    
+
     q = ConcatSignal(*p)
-    
+
     @always_comb
     def assign():
         x.next = q


### PR DESCRIPTION
The built-in *bin* function omits *leading zeroes* which results in a mismatch of the lengths between the LHS and the RHS. Using the MyHDL *bin* function with a width specifier remedies this.