### PR TITLE
Std logic ports shadow signals

### DIFF
--- a/myhdl/_ShadowSignal.py
+++ b/myhdl/_ShadowSignal.py
@@ -84,16 +84,20 @@ class _SliceSignal(_ShadowSignal):
             set_next(self, sig[left:right])
             yield sig
 
-    def _setName(self, hdl):
+    def _setName(self, hdl, convertoplevelport):
         if self._right is None:
             if hdl == 'Verilog':
                 self._name = "%s[%s]" % (self._sig._name, self._left)
             else:
-                self._name = "%s(%s)" % (self._sig._name, self._left)
+                self._name = "%s%s(%s)" % (self._sig._name, '_num' if convertoplevelport and self._sig._toplevelport else '', self._left)
         else:
             if hdl == 'Verilog':
                 self._name = "%s[%s-1:%s]" % (self._sig._name, self._left, self._right)
             else:
+                if self._sig._min < 0:
+                    self._name = "unsigned( %s%s(%s-1 downto %s))" % (self._sig._name, '_num' if convertoplevelport and self._sig._toplevelport else '', self._left, self._right)
+                else:
+                    self._name = "%s%s(%s-1 downto %s)" % (self._sig._name, '_num' if convertoplevelport and self._sig._toplevelport else '', self._left, self._right)
                 self._name = "%s(%s-1 downto %s)" % (self._sig._name, self._left, self._right)
 
     def _markRead(self):

--- a/myhdl/_ShadowSignal.py
+++ b/myhdl/_ShadowSignal.py
@@ -98,7 +98,6 @@ class _SliceSignal(_ShadowSignal):
                     self._name = "unsigned( %s%s(%s-1 downto %s))" % (self._sig._name, '_num' if convertoplevelport and self._sig._toplevelport else '', self._left, self._right)
                 else:
                     self._name = "%s%s(%s-1 downto %s)" % (self._sig._name, '_num' if convertoplevelport and self._sig._toplevelport else '', self._left, self._right)
-                self._name = "%s(%s-1 downto %s)" % (self._sig._name, self._left, self._right)
 
     def _markRead(self):
         self._read = True

--- a/myhdl/_Signal.py
+++ b/myhdl/_Signal.py
@@ -113,7 +113,7 @@ class _Signal(object):
                  '_setNextVal', '_copyVal2Next', '_printVcd', 
                  '_driven' ,'_read', '_name', '_used', '_inList',
                  '_waiter', 'toVHDL', 'toVerilog', '_slicesigs',
-                 '_numeric'
+                 '_numeric', '_toplevelport'
                 )
 
 
@@ -132,6 +132,7 @@ class _Signal(object):
         self._inList = False
         self._nrbits = 0
         self._numeric = True
+        self._toplevelport = False
         self._printVcd = self._printVcdStr
         if isinstance(val, bool):
             self._type = bool

--- a/myhdl/conversion/_analyze.py
+++ b/myhdl/conversion/_analyze.py
@@ -71,7 +71,7 @@ def _makeName(n, prefixes, namedict):
     return name
 
 
-def _analyzeSigs(hierarchy, hdl='Verilog'):
+def _analyzeSigs(hierarchy, hdl='Verilog', convertoplevelport = False):
     curlevel = 0
     siglist = []
     memlist = []
@@ -107,7 +107,8 @@ def _analyzeSigs(hierarchy, hdl='Verilog'):
                 raise ConversionError(_error.UndefinedBitWidth, s._name)
             # slice signals
             for sl in s._slicesigs:
-                sl._setName(hdl)
+                sl._setName(hdl, convertoplevelport)
+
             siglist.append(s)
         # list of signals
         for n, m in memdict.items():
@@ -1262,6 +1263,8 @@ def _analyzeTopFunc(top_inst, func, *args, **kwargs):
                 if not signame:
                     signame = name + '_' + attr
                     attrobj._name = signame
+                if signame in v.argdict:
+                    v.raiseError(signame, _error.SignalNameConflict, "generated signal name {{{}}} clashes with other signal names" .format(signame))
                 v.argdict[signame] = attrobj
                 v.argnames.append(signame)
 

--- a/myhdl/conversion/_misc.py
+++ b/myhdl/conversion/_misc.py
@@ -74,7 +74,7 @@ class _error(object):
     PortInList = "Port in list is not supported"
     ListAsPort = "List of signals as a port is not supported"
     SignalInMultipleLists = "Signal in multiple list is not supported"
-
+    SignalNameConflict = "SignalNameConflict"
 
 class _access(object):
     INPUT, OUTPUT, INOUT, UNKNOWN = range(4)

--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -165,15 +165,23 @@ class _ToVHDLConvertor(object):
 
         arglist = _flatten(h.top)
         _checkArgs(arglist)
-        genlist = _analyzeGens(arglist, h.absnames)
-        siglist, memlist = _analyzeSigs(h.hierarchy, hdl='VHDL')
-        # print h.top
-        _annotateTypes(genlist)
 
+        # 26-05-2015 jb moved this here
         ### infer interface
         top_inst = h.hierarchy[0]
         intf = _analyzeTopFunc(top_inst, func, *args, **kwargs)
         intf.name = name
+        # have intf, can now flag the port signals ...
+        if intf.argnames:
+            for portname in intf.argnames:
+                print( portname )
+        for arg in intf.args:
+            if isinstance(arg, _Signal):
+                arg._toplevelport = True
+
+        genlist = _analyzeGens(arglist, h.absnames)
+        siglist, memlist = _analyzeSigs(h.hierarchy, hdl='VHDL', convertoplevelport = self.std_logic_ports)
+        _annotateTypes(genlist)
         # sanity checks on interface
         for portname in intf.argnames:
             s = intf.argdict[portname]

--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -112,7 +112,7 @@ class _ToVHDLConvertor(object):
         self.library = "work"
         self.use_clauses = None
         self.architecture = "MyHDL"
-        self.std_logic_ports = False 
+        self.std_logic_ports = False
 
     def __call__(self, func, *args, **kwargs):
         global _converting
@@ -172,9 +172,6 @@ class _ToVHDLConvertor(object):
         intf = _analyzeTopFunc(top_inst, func, *args, **kwargs)
         intf.name = name
         # have intf, can now flag the port signals ...
-        if intf.argnames:
-            for portname in intf.argnames:
-                print( portname )
         for arg in intf.args:
             if isinstance(arg, _Signal):
                 arg._toplevelport = True

--- a/myhdl/test/conversion/general/test_interfaces2.py
+++ b/myhdl/test/conversion/general/test_interfaces2.py
@@ -4,6 +4,7 @@ import sys
 
 from myhdl import *
 from myhdl.conversion import analyze,verify
+from myhdl.test.conversion.conftest import bug
 
 class Intf(object):
     def __init__(self):
@@ -69,7 +70,7 @@ def name_conflict_after_replace(clock, reset, a, a_x):
 
     return logic
 
-
+@bug('80')
 def test_name_conflict_after_replace():
     clock = Signal(False)
     reset = ResetSignal(0, active=0, async=False)


### PR DESCRIPTION
See #80 where I describe an Issue with ShadowSignals from a top-level std_logic_vector port.
As a result of moving the _analyzeTopFunc() forward the original renaming of conflicting generated signals from an interface object is now skipped.
I find silently renaming a less nice solution and added code to raise an error. Also read #64. IMHO I think this will be very rare, and if it arises I prefer changing the naming myself rather than see that (dare I say awkward)  mangled name in the VHDL code.