### PR TITLE
Windows support for co-simulation

### DIFF
--- a/cosimulation/modelsim-win/Makefile
+++ b/cosimulation/modelsim-win/Makefile
@@ -1,0 +1,21 @@
+INCS := C:\\modeltech64_10.4\\include
+LIB_PATH := C:\\modeltech64_10.4\\win64
+
+ifneq ($(filter cl%,$(CC)),)
+	CFLAGS := /LD /I$(INCS)
+	LIBFLAGS := $(LIB_PATH)\\mtipli.lib
+else
+	CFLAGS := -static -g -I$(INCS) -o myhdl_vpi.dll
+	LIBFLAGS := -L$(LIB_PATH) -lmtipli
+endif
+
+all: myhdl_vpi.dll
+
+myhdl_vpi.dll: myhdl_vpi.c
+	$(CC) $(CFLAGS) $< $(LIBFLAGS)
+
+clean:
+	@del /q myhdl_vpi.dll || rm -rf myhdl_vpi.dll 2>&1> /dev/null ||:
+	@del /q myhdl_vpi.lib || rm -rf myhdl_vpi.lib 2>&1> /dev/null ||:
+	@del /q myhdl_vpi.exp || rm -rf myhdl_vpi.exp 2>&1> /dev/null ||:
+	@del /q myhdl_vpi.obj || rm -rf myhdl_vpi.obj 2>&1> /dev/null ||:

--- a/cosimulation/modelsim-win/myhdl_vpi.c
+++ b/cosimulation/modelsim-win/myhdl_vpi.c
@@ -163,7 +163,7 @@ static PLI_INT32 from_myhdl_calltf(PLI_BYTE8 *user_data)
 
   n = write_pipe(buf, strlen(buf));
 
-  if ((n = read_pipe(buf, MAXLINE)) == 0) {
+  if ((n = read_pipe(buf, MAXLINE)) <= 0) {
     vpi_printf("Info: MyHDL simulator down\n");
     vpi_control(vpiFinish, 1);  /* abort simulation */
     return(0);
@@ -242,7 +242,7 @@ static PLI_INT32 to_myhdl_calltf(PLI_BYTE8 *user_data)
 
   n = write_pipe(buf, strlen(buf));
 
-  if ((n = read_pipe(buf, MAXLINE)) == 0) {
+  if ((n = read_pipe(buf, MAXLINE)) <= 0) {
     vpi_printf("ABORT from $to_myhdl\n");
     vpi_control(vpiFinish, 1);  /* abort simulation */
     return(0);
@@ -300,7 +300,7 @@ static PLI_INT32 readonly_callback(p_cb_data cb_data)
     start_flag = 0;
     n = write_pipe("START", 5);
     // vpi_printf("INFO: RO cb at start-up\n");
-    if ((n = read_pipe(buf, MAXLINE)) == 0) {
+    if ((n = read_pipe(buf, MAXLINE)) <= 0) {
       vpi_printf("ABORT from RO cb at start-up\n");
       vpi_control(vpiFinish, 1);  /* abort simulation */
     }
@@ -337,7 +337,7 @@ static PLI_INT32 readonly_callback(p_cb_data cb_data)
   //vpi_free_object(net_iter);
 
   n = write_pipe(buf, strlen(buf));
-  if ((n = read_pipe(buf, MAXLINE)) == 0) {
+  if ((n = read_pipe(buf, MAXLINE)) <= 0) {
     // vpi_printf("ABORT from RO cb\n");
     vpi_control(vpiFinish, 1);  /* abort simulation */
     return(0);

--- a/cosimulation/modelsim-win/test/bin2gray.py
+++ b/cosimulation/modelsim-win/test/bin2gray.py
@@ -1,0 +1,13 @@
+import os
+
+from myhdl import Cosimulation
+
+cmd = 'vsim -c -quiet -pli ../myhdl_vpi.so -do cosim.do dut_bin2gray'
+       
+def bin2gray(B, G, width):
+    os.system('vlog -quiet +define+width=%s ../../test/verilog/bin2gray.v' % (width))
+    os.system('vlog -quiet +define+width=%s ../../test/verilog/dut_bin2gray.v' % (width)) 
+
+    return Cosimulation(cmd, B=B, G=G)
+               
+

--- a/cosimulation/modelsim-win/test/bin2gray.py
+++ b/cosimulation/modelsim-win/test/bin2gray.py
@@ -2,12 +2,10 @@ import os
 
 from myhdl import Cosimulation
 
-cmd = 'vsim -c -quiet -pli ../myhdl_vpi.so -do cosim.do dut_bin2gray'
-       
+cmd = 'vsim -c -quiet -pli ../myhdl_vpi.dll -do cosim.do dut_bin2gray'
+
 def bin2gray(B, G, width):
     os.system('vlog -quiet +define+width=%s ../../test/verilog/bin2gray.v' % (width))
-    os.system('vlog -quiet +define+width=%s ../../test/verilog/dut_bin2gray.v' % (width)) 
+    os.system('vlog -quiet +define+width=%s ../../test/verilog/dut_bin2gray.v' % (width))
 
     return Cosimulation(cmd, B=B, G=G)
-               
-

--- a/cosimulation/modelsim-win/test/cosim.do
+++ b/cosimulation/modelsim-win/test/cosim.do
@@ -1,0 +1,2 @@
+run -all
+quit

--- a/cosimulation/modelsim-win/test/dff.py
+++ b/cosimulation/modelsim-win/test/dff.py
@@ -1,0 +1,12 @@
+import os
+
+from myhdl import Cosimulation
+
+cmd = 'vsim -c -quiet -pli ../myhdl_vpi.so -do cosim.do dut_dff'
+      
+def dff(q, d, clk, reset):
+    os.system('vlog -quiet ../../test/verilog/dff.v')
+    os.system('vlog -quiet ../../test/verilog/dut_dff.v') 
+
+    return Cosimulation(cmd, **locals())
+               

--- a/cosimulation/modelsim-win/test/dff.py
+++ b/cosimulation/modelsim-win/test/dff.py
@@ -2,11 +2,10 @@ import os
 
 from myhdl import Cosimulation
 
-cmd = 'vsim -c -quiet -pli ../myhdl_vpi.so -do cosim.do dut_dff'
-      
+cmd = 'vsim -c -quiet -pli ../myhdl_vpi.dll -do cosim.do dut_dff'
+
 def dff(q, d, clk, reset):
     os.system('vlog -quiet ../../test/verilog/dff.v')
-    os.system('vlog -quiet ../../test/verilog/dut_dff.v') 
+    os.system('vlog -quiet ../../test/verilog/dut_dff.v')
 
     return Cosimulation(cmd, **locals())
-               

--- a/cosimulation/modelsim-win/test/dff_clkout.py
+++ b/cosimulation/modelsim-win/test/dff_clkout.py
@@ -1,0 +1,13 @@
+import os
+import os.path as path
+
+from myhdl import Cosimulation
+
+cmd = 'vsim -c -quiet -pli ../myhdl_vpi.so -do cosim.do dut_dff_clkout'
+      
+def dff_clkout(clkout, q, d, clk, reset):
+    os.system('vlog -quiet ../../test/verilog/dff_clkout.v')
+    os.system('vlog -quiet ../../test/verilog/dut_dff_clkout.v')
+    
+    return Cosimulation(cmd, **locals())
+               

--- a/cosimulation/modelsim-win/test/dff_clkout.py
+++ b/cosimulation/modelsim-win/test/dff_clkout.py
@@ -1,13 +1,11 @@
 import os
-import os.path as path
 
 from myhdl import Cosimulation
 
-cmd = 'vsim -c -quiet -pli ../myhdl_vpi.so -do cosim.do dut_dff_clkout'
-      
+cmd = 'vsim -c -quiet -pli ../myhdl_vpi.dll -do cosim.do dut_dff_clkout'
+
 def dff_clkout(clkout, q, d, clk, reset):
     os.system('vlog -quiet ../../test/verilog/dff_clkout.v')
     os.system('vlog -quiet ../../test/verilog/dut_dff_clkout.v')
-    
+
     return Cosimulation(cmd, **locals())
-               

--- a/cosimulation/modelsim-win/test/inc.py
+++ b/cosimulation/modelsim-win/test/inc.py
@@ -1,0 +1,12 @@
+import os
+
+from myhdl import Cosimulation
+
+cmd = 'vsim -c -quiet -pli ../myhdl_vpi.so -do cosim.do dut_inc'
+
+def inc(count, enable, clock, reset, n):
+    os.system('vlog -quiet +define+n=%s ../../test/verilog/inc.v' % (n))
+    os.system('vlog -quiet +define+n=%s ../../test/verilog/dut_inc.v' % (n)) 
+
+    return Cosimulation(cmd, **locals())
+               

--- a/cosimulation/modelsim-win/test/inc.py
+++ b/cosimulation/modelsim-win/test/inc.py
@@ -2,11 +2,10 @@ import os
 
 from myhdl import Cosimulation
 
-cmd = 'vsim -c -quiet -pli ../myhdl_vpi.so -do cosim.do dut_inc'
+cmd = 'vsim -c -quiet -pli ../myhdl_vpi.dll -do cosim.do dut_inc'
 
 def inc(count, enable, clock, reset, n):
     os.system('vlog -quiet +define+n=%s ../../test/verilog/inc.v' % (n))
-    os.system('vlog -quiet +define+n=%s ../../test/verilog/dut_inc.v' % (n)) 
+    os.system('vlog -quiet +define+n=%s ../../test/verilog/dut_inc.v' % (n))
 
     return Cosimulation(cmd, **locals())
-               

--- a/cosimulation/modelsim-win/test/test_all.py
+++ b/cosimulation/modelsim-win/test/test_all.py
@@ -1,0 +1,47 @@
+#  This file is part of the myhdl library, a Python package for using
+#  Python as a Hardware Description Language.
+#
+#  Copyright (C) 2003-2008 Jan Decaluwe
+#
+#  The myhdl library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation; either version 2.1 of the
+#  License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+""" Run cosimulation unit tests. """
+
+
+import sys
+
+sys.path.append("../../test")
+
+import test_bin2gray, test_inc, test_dff
+
+# modules = (test_dff,  )
+modules = (test_bin2gray, test_inc, test_dff )
+
+import unittest
+
+tl = unittest.defaultTestLoader
+def suite():
+    alltests = unittest.TestSuite()
+    for m in modules:
+        alltests.addTest(tl.loadTestsFromModule(m))
+    return alltests
+
+def main():
+    unittest.main(defaultTest='suite',
+                  testRunner=unittest.TextTestRunner(verbosity=2))
+    
+
+if __name__ == '__main__':
+    main()

--- a/cosimulation/modelsim-win/test/test_all.py
+++ b/cosimulation/modelsim-win/test/test_all.py
@@ -41,7 +41,7 @@ def suite():
 def main():
     unittest.main(defaultTest='suite',
                   testRunner=unittest.TextTestRunner(verbosity=2))
-    
+
 
 if __name__ == '__main__':
     main()

--- a/myhdl/_Cosimulation.py
+++ b/myhdl/_Cosimulation.py
@@ -29,7 +29,7 @@ if sys.platform == "win32":
 
 from myhdl._intbv import intbv
 from myhdl import _simulator, CosimulationError
-from myhdl._compat import PY2, string_types, to_bytes, to_str
+from myhdl._compat import string_types, to_bytes, to_str
 
 _MAXLINE = 4096
 
@@ -108,10 +108,13 @@ class Cosimulation(object):
         self._getMode = 1
 
         env = os.environ.copy()
-        env['MYHDL_TO_PIPE'] = str(wt) if sys.platform != "win32"
-                               else str(msvcrt.get_osfhandle(wt))
-        env['MYHDL_FROM_PIPE'] = str(rf) if sys.platform != "win32"
-                                 else str(msvcrt.get_osfhandle(rf))
+
+        if sys.platform != "win32":
+            env['MYHDL_TO_PIPE'] = str(wt)
+            env['MYHDL_FROM_PIPE'] = str(rf)
+        else:
+            env['MYHDL_TO_PIPE'] = str(msvcrt.get_osfhandle(wt))
+            env['MYHDL_FROM_PIPE'] = str(msvcrt.get_osfhandle(rf))
 
         if isinstance(exe, string_types):
             exe = shlex.split(exe)

--- a/myhdl/_util.py
+++ b/myhdl/_util.py
@@ -96,6 +96,10 @@ def _genfunc(gen):
 if hasattr(os, 'set_inheritable'):
     _setInheritable = os.set_inheritable
 else:
+# This implementation of set_inheritable is based on a code sample in
+# [PEP 0446](https://www.python.org/dev/peps/pep-0446/) and on the
+# CPython implementation of that proposal which can be browsed [here]
+# (hg.python.org/releasing/3.4/file/8671f89107c8/Modules/posixmodule.c#l11130)
     def _setInheritable(fd, inheritable):
         if sys.platform == "win32":
             import msvcrt


### PR DESCRIPTION
Added support for windows pipes to allow co-simulation in the Windows version of ModelSim.
Currently only the ModelSim bridge has been updated because this is what I needed to work with. Initial tests show that it's still building and working as expected on Linux, but more test environments are needed to make sure nothing is broken because of this.

Also fixes #38 