### PR TITLE
fixed VHDL variable conversion issue in test_interface4

### DIFF
--- a/myhdl/test/conversion/general/test_interfaces4.py
+++ b/myhdl/test/conversion/general/test_interfaces4.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 
 import sys
 
-import pytest
-
 from myhdl import *
 from myhdl import ConversionError
 from myhdl.conversion._misc import _error
@@ -110,9 +108,13 @@ def c_testbench_one():
         while True:
             yield delay(3)
             clock.next = not clock
-        
-    expected = (False, False, False, True, True, True,
-                False, True, False, True)
+     
+    # there is an issue when using bools with varialbes and
+    # VHDL conversion, this might be an expected limitation?
+    #expected = (False, False, False, True, True, True,
+    #            False, True, False, True)
+    expected = (0, 0, 0, 1, 1, 1, 0, 1, 0, 1)
+
     ra = reset.active    
     @instance
     def tbstim():
@@ -123,10 +125,8 @@ def c_testbench_one():
         yield clock.posedge
         for ii in range(10):
             print("sdi: %d, sdo: %d" % (sdi, sdo))
-            # The following two lines run into an unrelated VHDL tuple
-            # conversion bug.
-            # expected_bit = expected[ii]
-            # assert sdo == expected_bit
+            expected_bit = expected[ii]
+            assert sdo == expected_bit
             sdi.next = not sdi
             yield clock.posedge
 
@@ -153,6 +153,7 @@ def test_one_analyze():
 
 def test_one_verify():
     assert verify(c_testbench_one) == 0
+
 
 def test_conversion():
     toVerilog(c_testbench_one)


### PR DESCRIPTION
There appears to be a VHDL conversion issue when using `bool` with a variable.  Not clear if this is a known limitation or a bug.  If this is a bug I can create a new issue.  The following simple test shows the issue.

```python
from myhdl.conversion import analyze, verify

def bench():
    expected = (False, False, True, False, True, True)
    nbits = len(expected)
    previous = Signal(bool(0))
    @instance
    def tbstim():
        for ii in range(0, nbits):
            ebitnow = expected[ii]
            previous.next = ebitnow
            if ii > 0:
                ebitpre = expected[ii-1]
                assert previous == ebitpre
            yield delay(1)

    return tbstim

def test(): 
    Simulation(bench()).run()
    assert analyze(bench)
    assert verify(bench) == 0

verify.simulator = analyze.simulator = 'GHDL'
test()
```
    