### PR TITLE
Initial value support

### DIFF
--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -100,6 +100,7 @@ class _ToVHDLConvertor(object):
                  "use_clauses",
                  "architecture",
                  "std_logic_ports",
+                 "disable_initial_value"
                  )
 
     def __init__(self):
@@ -113,6 +114,7 @@ class _ToVHDLConvertor(object):
         self.use_clauses = None
         self.architecture = "MyHDL"
         self.std_logic_ports = False
+        self.disable_initial_value = True
 
     def __call__(self, func, *args, **kwargs):
         global _converting
@@ -403,8 +405,10 @@ def _writeSigDecls(f, intf, siglist, memlist):
                               category=ToVHDLWarning
                               )
             # the following line implements initial value assignments
-            # print >> f, "%s %s%s = %s;" % (s._driven, r, s._name, int(s._val))
-            print("signal %s: %s%s;" % (s._name, p, r), file=f)
+            if toVHDL.disable_initial_value:
+                print("signal %s: %s%s;" % (s._name, p, r), file=f)
+            else:
+                print("signal %s: %s%s = %s;" % (s._name, p, r, int(s._val)), file=f)
         elif s._read:
             # the original exception
             # raise ToVHDLError(_error.UndrivenSignal, s._name)

--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -405,10 +405,22 @@ def _writeSigDecls(f, intf, siglist, memlist):
                               category=ToVHDLWarning
                               )
             # the following line implements initial value assignments
+
+            sig_vhdl_obj = inferVhdlObj(s)
+
             if toVHDL.disable_initial_value:
-                print("signal %s: %s%s;" % (s._name, p, r), file=f)
+                val_str = ""
             else:
-                print("signal %s: %s%s = %s;" % (s._name, p, r, int(s._val)), file=f)
+                
+                if isinstance(sig_vhdl_obj, vhd_std_logic):
+                    val_str = " := '%s'" % int(s._init)
+                elif isinstance(sig_vhdl_obj, vhd_int):
+                    val_str = " := %s" % s._init
+                else:
+                    val_str = ' := "%s"' % bin(s._init, sig_vhdl_obj.size)
+            
+            print("signal %s: %s%s%s;" % (s._name, p, r, val_str), file=f)
+
         elif s._read:
             # the original exception
             # raise ToVHDLError(_error.UndrivenSignal, s._name)

--- a/myhdl/conversion/_toVerilog.py
+++ b/myhdl/conversion/_toVerilog.py
@@ -297,7 +297,7 @@ def _writeSigDecls(f, intf, siglist, memlist):
                 print("%s %s%s%s;" % (k, p, r, s._name), file=f)
             else:
                 print("%s %s%s%s = %s;" % 
-                      (k, p, r, s._name, _intRepr(s._val)), file=f)
+                      (k, p, r, s._name, _intRepr(s._init)), file=f)
         elif s._read:
             # the original exception
             # raise ToVerilogError(_error.UndrivenSignal, s._name)

--- a/myhdl/conversion/_toVerilog.py
+++ b/myhdl/conversion/_toVerilog.py
@@ -95,7 +95,8 @@ class _ToVerilogConvertor(object):
                  "no_myhdl_header",
                  "no_testbench",
                  "portmap",
-                 "trace"
+                 "trace",
+                 "disable_initial_value"
                  )
 
     def __init__(self):
@@ -109,6 +110,7 @@ class _ToVerilogConvertor(object):
         self.no_myhdl_header = False
         self.no_testbench = False
         self.trace = False
+        self.disable_initial_value = True
 
     def __call__(self, func, *args, **kwargs):
         global _converting
@@ -289,8 +291,12 @@ def _writeSigDecls(f, intf, siglist, memlist):
             if s._driven == 'reg':
                 k = 'reg'
             # the following line implements initial value assignments
-            # print >> f, "%s %s%s = %s;" % (k, r, s._name, int(s._val))
-            print("%s %s%s%s;" % (k, p, r, s._name), file=f)
+            # don't initial value "wire", inital assignment to a wire
+            # equates to a continuous assignment [reference]
+            if toVerilog.disable_initial_value or k == 'wire':
+                print("%s %s%s%s;" % (k, p, r, s._name), file=f)
+            else:
+                print("%s %s%s%s = %s;" % (k, p, r, s._name, int(s._val)), file=f)
         elif s._read:
             # the original exception
             # raise ToVerilogError(_error.UndrivenSignal, s._name)

--- a/myhdl/conversion/_toVerilog.py
+++ b/myhdl/conversion/_toVerilog.py
@@ -296,7 +296,8 @@ def _writeSigDecls(f, intf, siglist, memlist):
             if toVerilog.disable_initial_value or k == 'wire':
                 print("%s %s%s%s;" % (k, p, r, s._name), file=f)
             else:
-                print("%s %s%s%s = %s;" % (k, p, r, s._name, int(s._val)), file=f)
+                print("%s %s%s%s = %s;" % 
+                      (k, p, r, s._name, _intRepr(s._val)), file=f)
         elif s._read:
             # the original exception
             # raise ToVerilogError(_error.UndrivenSignal, s._name)
@@ -396,6 +397,24 @@ def _getSignString(s):
     else:
         return ''
 
+def _intRepr(n, radix=''):
+    # write size for large integers (beyond 32 bits signed)
+    # with some safety margin
+    # XXX signed indication 's' ???
+    p = abs(n)
+    size = ''
+    num = str(p).rstrip('L')
+    if radix == "hex" or p >= 2**30:
+        radix = "'h"
+        num = hex(p)[2:].rstrip('L')
+    if p >= 2**30:
+        size = int(math.ceil(math.log(p+1,2))) + 1  # sign bit!
+#            if not radix:
+#                radix = "'d"
+    r = "%s%s%s" % (size, radix, num)
+    if n < 0: # add brackets and sign on negative numbers
+        r = "(-%s)" % r
+    return r
 
 def _convertGens(genlist, vfile):
     blockBuf = StringIO()
@@ -495,23 +514,7 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
         self.ind = self.ind[:-4]
 
     def IntRepr(self, n, radix=''):
-        # write size for large integers (beyond 32 bits signed)
-        # with some safety margin
-        # XXX signed indication 's' ???
-        p = abs(n)
-        size = ''
-        num = str(p).rstrip('L')
-        if radix == "hex" or p >= 2**30:
-            radix = "'h"
-            num = hex(p)[2:].rstrip('L')
-        if p >= 2**30:
-            size = int(math.ceil(math.log(p+1,2))) + 1  # sign bit!
-#            if not radix:
-#                radix = "'d"
-        r = "%s%s%s" % (size, radix, num)
-        if n < 0: # add brackets and sign on negative numbers
-            r = "(-%s)" % r
-        return r
+        return _intRepr(n, radix)
 
     def writeDeclaration(self, obj, name, dir):
         if dir: dir = dir + ' '

--- a/myhdl/test/conversion/non_vpi/veriutils.cfg
+++ b/myhdl/test/conversion/non_vpi/veriutils.cfg
@@ -1,0 +1,5 @@
+[General]
+part=xc7z020clg484-1
+
+[tcl template paths]
+simulate=vivado_simulate.tcl.tmpl

--- a/myhdl/test/conversion/non_vpi/vivado_simulate.tcl.tmpl
+++ b/myhdl/test/conversion/non_vpi/vivado_simulate.tcl.tmpl
@@ -1,0 +1,13 @@
+config_webtalk -user off
+create_project $project_name $project_path -part $part
+
+set_property target_language $target_language [current_project]
+add_files -norecurse {$xci_files $vhdl_files $verilog_files $ip_additional_hdl_files}
+
+update_compile_order -fileset sources_1
+update_compile_order -fileset sim_1
+generate_target {simulation} [get_files {$xci_files}]
+set_property -name {xsim.simulate.runtime} -value {${time}ns} -objects [current_fileset -simset]
+launch_simulation
+close_sim
+close_project

--- a/myhdl/test/conversion/non_vpi/vivado_tests.py
+++ b/myhdl/test/conversion/non_vpi/vivado_tests.py
@@ -1,0 +1,205 @@
+
+import unittest
+from myhdl import *
+from random import randrange
+
+import os
+
+veriutils_available = True
+try:
+    from veriutils import (
+        vivado_verilog_cosimulation, vivado_vhdl_cosimulation, 
+        myhdl_cosimulation, copy_signal, VIVADO_EXECUTABLE)
+
+except ImportError:
+    veriutils_available = False
+
+# The config files are in the same dir as this file
+_config_path = os.path.split(__file__)[0]
+_config_file = os.path.join(_config_path, 'veriutils.cfg')
+_template_prefix = _config_path
+
+def trivial(input_signal, output_signal, clock):
+
+    @always(clock.posedge)
+    def trivial_instance():
+
+        output_signal.next = input_signal
+
+    return trivial_instance
+
+@unittest.skipIf(not veriutils_available, 'Veriutils cannot be imported.')
+@unittest.skipIf(VIVADO_EXECUTABLE is None, 'Vivado executable not in path')
+class InitialValueTestMixin(object):
+
+    def cosimulate(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def setUp(self):
+        self._verilog_disable_initial_value = toVerilog.disable_initial_value
+        self._vhdl_disable_initial_value = toVHDL.disable_initial_value
+
+        toVerilog.disable_initial_value = False
+        toVHDL.disable_initial_value = False
+
+        self.args = {'clock': Signal(False)}
+        self.arg_types = {'input_signal': 'custom',
+                          'output_signal': 'output',
+                          'clock': 'clock'}
+
+    def tearDown(self):
+        toVerilog.disable_initial_value = self._verilog_disable_initial_value
+        toVHDL.disable_initial_value = self._vhdl_disable_initial_value
+
+    def test_unsigned(self):
+        '''The correct initial value should be used for unsigned type signal.
+
+        The initial value should be derived from the _init attribute of the 
+        signal.
+        '''
+
+        min_val = 0
+        max_val = 35
+
+        self.args['input_signal'] = Signal(intbv(randrange(min_val, max_val), 
+                                                 min=min_val, max=max_val))
+        self.args['output_signal'] = Signal(intbv(randrange(min_val, max_val), 
+                                                  min=min_val, max=max_val))
+
+        test_cycles = 10
+
+        expected_outputs = (
+            [int(self.args['output_signal']._init)] + 
+            [int(self.args['input_signal']._init)] * (test_cycles - 1))
+
+        dut_signals, ref_signals = self.cosimulate(
+            test_cycles, trivial, trivial, self.args, self.arg_types, 
+            config_file=_config_file, template_path_prefix=_template_prefix)
+
+        self.assertTrue(ref_signals['output_signal'] == expected_outputs)        
+        self.assertTrue(dut_signals['output_signal'] == expected_outputs)
+
+    def test_signed(self):
+        '''The correct initial value should be used for a signed type signal.
+
+        The initial value should be derived from the _init attribute of the 
+        signal.
+        '''
+
+        min_val = -12
+        max_val = 4
+
+        self.args['input_signal'] = Signal(intbv(randrange(min_val, max_val), 
+                                                 min=min_val, max=max_val))
+        self.args['output_signal'] = Signal(intbv(randrange(min_val, max_val), 
+                                                  min=min_val, max=max_val))
+
+        test_cycles = 10
+
+        expected_outputs = (
+            [int(self.args['output_signal']._init)] + 
+            [int(self.args['input_signal']._init)] * (test_cycles - 1))
+
+        dut_signals, ref_signals = self.cosimulate(
+            test_cycles, trivial, trivial, self.args, self.arg_types, 
+            config_file=_config_file, template_path_prefix=_template_prefix)
+
+        self.assertTrue(ref_signals['output_signal'] == expected_outputs)        
+        self.assertTrue(dut_signals['output_signal'] == expected_outputs)
+
+    def test_long_signals(self):
+        '''The correct initial value should work with wide bitwidths.
+
+        Specifically, it should not suffer from problems in which number
+        must fit into a specific bitwidth (e.g. 32-bit integers)
+        '''
+
+        # Use a 72-bit signed intbv (bigger than a 32- or 64-bit integer)
+        min_val = -(2**71)
+        max_val = 2**71 - 1
+
+        self.args['input_signal'] = Signal(intbv(randrange(min_val, max_val), 
+                                                 min=min_val, max=max_val))
+        self.args['output_signal'] = Signal(intbv(randrange(min_val, max_val), 
+                                                  min=min_val, max=max_val))
+
+        test_cycles = 10
+
+        expected_outputs = (
+            [int(self.args['output_signal']._init)] + 
+            [int(self.args['input_signal']._init)] * (test_cycles - 1))
+
+        dut_signals, ref_signals = self.cosimulate(
+            test_cycles, trivial, trivial, self.args, self.arg_types, 
+            config_file=_config_file, template_path_prefix=_template_prefix)
+
+        self.assertTrue(ref_signals['output_signal'] == expected_outputs)        
+        self.assertTrue(dut_signals['output_signal'] == expected_outputs)
+
+    def test_boolean(self):
+        '''The correct initial value should be used for a boolean type signal.
+
+        The initial value should be derived from the _init attribute of the 
+        signal.
+        '''
+
+        self.args['input_signal'] = Signal(False)
+        self.args['output_signal'] = Signal(True)
+
+        test_cycles = 10
+
+        expected_outputs = (
+            [bool(self.args['output_signal']._init)] + 
+            [bool(self.args['input_signal']._init)] * (test_cycles - 1))
+
+        dut_signals, ref_signals = self.cosimulate(
+            test_cycles, trivial, trivial, self.args, self.arg_types, 
+            config_file=_config_file, template_path_prefix=_template_prefix)
+
+        self.assertTrue(ref_signals['output_signal'] == expected_outputs)        
+        self.assertTrue(dut_signals['output_signal'] == expected_outputs)
+
+    def test_init_used(self):
+        '''It should be the _init attribute that is used for initialisation
+
+        It should not be the current value, which should be ignored.
+        '''
+
+        min_val = -12
+        max_val = 4
+
+        self.args['input_signal'] = Signal(intbv(randrange(min_val, max_val), 
+                                                 min=min_val-1, max=max_val))
+        self.args['output_signal'] = Signal(intbv(randrange(min_val, max_val), 
+                                                  min=min_val-1, max=max_val))
+
+        test_cycles = 10
+
+        expected_outputs = (
+            [int(self.args['output_signal']._init)] + 
+            [int(self.args['input_signal']._init)] * (test_cycles - 1))
+
+        # Get the reference pre-hackery
+        _, ref_signals = myhdl_cosimulation(
+            test_cycles, trivial, trivial, self.args, self.arg_types)
+
+        self.args['input_signal']._val = self.args['input_signal'].val - 1
+        self.args['output_signal']._val = self.args['output_signal'].val - 1
+
+        dut_signals, _ = self.cosimulate(
+            test_cycles, trivial, trivial, self.args, self.arg_types, 
+            config_file=_config_file, template_path_prefix=_template_prefix)
+
+        self.assertTrue(ref_signals['output_signal'] == expected_outputs)        
+        self.assertTrue(dut_signals['output_signal'] == expected_outputs)
+
+
+class InitialValueVerilogTests(InitialValueTestMixin, unittest.TestCase):
+
+    def cosimulate(self, *args, **kwargs):
+        return vivado_verilog_cosimulation(*args, **kwargs)
+
+class InitialValueVHDLTests(InitialValueTestMixin, unittest.TestCase):
+
+    def cosimulate(self, *args, **kwargs):
+        return vivado_vhdl_cosimulation(*args, **kwargs)

--- a/myhdl/test/conversion/non_vpi/vivado_tests.py
+++ b/myhdl/test/conversion/non_vpi/vivado_tests.py
@@ -183,12 +183,26 @@ class InitialValueTestMixin(object):
         _, ref_signals = myhdl_cosimulation(
             test_cycles, trivial, trivial, self.args, self.arg_types)
 
-        self.args['input_signal']._val = self.args['input_signal'].val - 1
-        self.args['output_signal']._val = self.args['output_signal'].val - 1
+        # Currently we're actually testing veriutils, not the conversion
+        # code...
+#        import veriutils
+#        def wrapped_Simulation(*args, **kwargs):
+#            result = Simulation(*args, **kwargs)
+#
+#            self.args['input_signal']._val = (
+#                self.args['input_signal'].val - 1)
+#            self.args['output_signal']._val = (
+#                self.args['output_signal'].val - 1)
+#
+#            return result
+
+#        veriutils.cosimulation.Simulation = wrapped_Simulation
 
         dut_signals, _ = self.cosimulate(
             test_cycles, trivial, trivial, self.args, self.arg_types, 
             config_file=_config_file, template_path_prefix=_template_prefix)
+
+#        veriutils.cosimulation.Simulation = Simulation
 
         self.assertTrue(ref_signals['output_signal'] == expected_outputs)        
         self.assertTrue(dut_signals['output_signal'] == expected_outputs)


### PR DESCRIPTION
Following cfelton's initial efforts and some discussion, this patch is adds initial value support to the toVHDL and toVerilog conversions.

Included are tests against Xilinx Vivado, which are all satisfied - these are necessarily non-vpi in nature (which is not supported by Vivado), so I've used the testing framework I developed for working with Vivado (veriutils). If Veriutils is not present, it gracefully fails and skips the tests.

Initial value support is enabled by setting disable_initial_value = False (which is default True). I suggest that the default being True allows a soft entry to asserting compatibility with the various toolchains as people have the time and inclination to test them.