### PR TITLE
Added Code to remove inappropriate warnings on Tristate Ports and TristateDrivers 

### DIFF
--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -325,10 +325,11 @@ def _writeModuleHeader(f, intf, needPck, lib, arch, useClauses, doc, stdLogicPor
             if convertPort:
                 pt = "std_logic_vector"
             if s._driven:
-                if s._read:
-                    warnings.warn("%s: %s" % (_error.OutputPortRead, portname),
-                                  category=ToVHDLWarning
-                                  )
+                if s._read :
+                    if not hasattr(s, 'driver'):
+                        warnings.warn("%s: %s" % (_error.OutputPortRead, portname),
+                                      category=ToVHDLWarning
+                                      )
                     f.write("\n        %s: inout %s%s" % (portname, pt, r))
                 else:
                     f.write("\n        %s: out %s%s" % (portname, pt, r))
@@ -398,7 +399,7 @@ def _writeSigDecls(f, intf, siglist, memlist):
         r = _getRangeString(s)
         p = _getTypeString(s)
         if s._driven:
-            if not s._read:
+            if not s._read and not hasattr(s, '_sig'):
                 warnings.warn("%s: %s" % (_error.UnreadSignal, s._name),
                               category=ToVHDLWarning
                               )

--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -53,6 +53,7 @@ from myhdl._Signal import _Signal,_WaiterList
 from myhdl.conversion._toVHDLPackage import _package
 from myhdl._util import  _flatten
 from myhdl._compat import integer_types, class_types, StringIO
+from myhdl._ShadowSignal import _TristateSignal, _TristateDriver
 
 
 _version = myhdl.__version__.replace('.','')
@@ -326,7 +327,7 @@ def _writeModuleHeader(f, intf, needPck, lib, arch, useClauses, doc, stdLogicPor
                 pt = "std_logic_vector"
             if s._driven:
                 if s._read :
-                    if not hasattr(s, 'driver'):
+                    if not isinstance(s, _TristateSignal):
                         warnings.warn("%s: %s" % (_error.OutputPortRead, portname),
                                       category=ToVHDLWarning
                                       )
@@ -399,7 +400,7 @@ def _writeSigDecls(f, intf, siglist, memlist):
         r = _getRangeString(s)
         p = _getTypeString(s)
         if s._driven:
-            if not s._read and not hasattr(s, '_sig'):
+            if not s._read and not isinstance(s, _TristateDriver):
                 warnings.warn("%s: %s" % (_error.UnreadSignal, s._name),
                               category=ToVHDLWarning
                               )

--- a/myhdl/conversion/_toVerilog.py
+++ b/myhdl/conversion/_toVerilog.py
@@ -50,7 +50,7 @@ from myhdl.conversion._misc import (_error, _kind, _context,
 from myhdl.conversion._analyze import (_analyzeSigs, _analyzeGens, _analyzeTopFunc,
                                        _Ram, _Rom)
 from myhdl._Signal import _Signal
-
+from myhdl._ShadowSignal import _TristateSignal, _TristateDriver
 
 _converting = 0
 _profileFunc = None
@@ -254,7 +254,7 @@ def _writeModuleHeader(f, intf, doc):
         p = _getSignString(s)
         if s._driven:
             if s._read :
-                if not hasattr(s, 'driver'):
+                if not isinstance(s, _TristateSignal):
                     warnings.warn("%s: %s" % (_error.OutputPortRead, portname),
                                   category=ToVerilogWarning
                                   )
@@ -282,7 +282,7 @@ def _writeSigDecls(f, intf, siglist, memlist):
         r = _getRangeString(s)
         p = _getSignString(s)
         if s._driven:
-            if not s._read and not hasattr(s, '_sig'):
+            if not s._read and not isinstance(s, _TristateDriver):
                 warnings.warn("%s: %s" % (_error.UnreadSignal, s._name),
                               category=ToVerilogWarning
                               )

--- a/myhdl/conversion/_toVerilog.py
+++ b/myhdl/conversion/_toVerilog.py
@@ -253,10 +253,11 @@ def _writeModuleHeader(f, intf, doc):
         r = _getRangeString(s)
         p = _getSignString(s)
         if s._driven:
-            if s._read:
-                warnings.warn("%s: %s" % (_error.OutputPortRead, portname),
-                              category=ToVerilogWarning
-                              )
+            if s._read :
+                if not hasattr(s, 'driver'):
+                    warnings.warn("%s: %s" % (_error.OutputPortRead, portname),
+                                  category=ToVerilogWarning
+                                  )
             print("output %s%s%s;" % (p, r, portname), file=f)
             if s._driven == 'reg':
                 print("reg %s%s%s;" % (p, r, portname), file=f)
@@ -281,7 +282,7 @@ def _writeSigDecls(f, intf, siglist, memlist):
         r = _getRangeString(s)
         p = _getSignString(s)
         if s._driven:
-            if not s._read:
+            if not s._read and not hasattr(s, '_sig'):
                 warnings.warn("%s: %s" % (_error.UnreadSignal, s._name),
                               category=ToVerilogWarning
                               )


### PR DESCRIPTION
The code:
```python
def top( sl, slv, sl_i, sl_o, slv_i, slv_en, slv_o ):

    sl_d = sl.driver()
    slv_d = slv.driver()

    @always_comb
    def hdl():
        sl_i.next = sl
        sl_d.next = False if not sl_o else None
           
        slv_i.next = slv
        slv_d.next = slv_o if slv_en else None

    return hdl
```
when converted, both VHDL and Verilog, will issue a warning for:
   1. the Output Ports  _sl_ and _slv_ being read
   2. the TristateDrivers _sl_d_ and _slv_d_ being driven but not read.

The proposed code adds checks to suppress those warnings.  