### PR TITLE
Added inout pot declaration to Verilog conversion for TristateSignals 

### DIFF
--- a/myhdl/conversion/_toVerilog.py
+++ b/myhdl/conversion/_toVerilog.py
@@ -258,7 +258,10 @@ def _writeModuleHeader(f, intf, doc):
                     warnings.warn("%s: %s" % (_error.OutputPortRead, portname),
                                   category=ToVerilogWarning
                                   )
-            print("output %s%s%s;" % (p, r, portname), file=f)
+            if isinstance(s, _TristateSignal):
+                print("inout %s%s%s;" % (p, r, portname), file=f)
+            else:
+                print("output %s%s%s;" % (p, r, portname), file=f)
             if s._driven == 'reg':
                 print("reg %s%s%s;" % (p, r, portname), file=f)
             else:


### PR DESCRIPTION

The `inout` port declaration was added in the case of `TristateSignal` 
used as ports.  Although, Verilog does not limit outputs from being
driven and read (removing the need for `inout` in inner modules) the 
synthesis tools require the `inout` declration to correctly infer 
input-output tristate buffers.  This was reported in #98 .

The following is a synthesis report for a simple design example before 
and after the modification:

**before**

```
Macro Statistics
# Registers                                            : 2
 Flip-Flops                                            : 2
# Shift Registers                                      : 2
 2-bit shift register                                  : 2

Primitive and Black Box Usage:
------------------------------
#      IBUF                        : 2
#      OBUF                        : 2
#      OBUFT                       : 2
```

**after**

```
HDL Synthesis Report

Macro Statistics
# Registers                                            : 4
 1-bit register                                        : 4
# Tristates                                            : 2
 1-bit tristate buffer                                 : 2

Primitive and Black Box Usage:
------------------------------
#      IBUF                        : 2
#      IOBUF                       : 2
#      OBUF                        : 2
```

The above results demonstrate that the FPGA synthesis tools failed
to infer an IOBUF for the `TristateSignal` ports.

Xilinx ISE 14.7 targetting a XC6SLX25 results are shown, the experiment
was also completed with Quartus but results not shown.