### PR TITLE
prevent adding intbv to senslist of always_comb

### DIFF
--- a/myhdl/_always_comb.py
+++ b/myhdl/_always_comb.py
@@ -126,7 +126,7 @@ class _AlwaysComb(_Always):
             s = self.symdict[n]
             if isinstance(s, _Signal):
                 senslist.append(s)
-            else: # list of sigs
+            elif _isListOfSigs(s):
                 senslist.extend(s)
         self.senslist = tuple(senslist)
         if len(self.senslist) == 0:


### PR DESCRIPTION
Since the merging of always_comb and always_seq NodeVisitors in #113,
intbvs are also added to the inputs by SigNameVisitor(in addition to
sigs and listofsigs). Since always_comb assumed that only sigs and
listofsigs are present in inputs, it wrongly addded intbvs to the
sensitivity list.