### PR TITLE
[enhancement] added scope-module// upscope around mem signals in.vcd

### DIFF
--- a/myhdl/_traceSignals.py
+++ b/myhdl/_traceSignals.py
@@ -179,6 +179,7 @@ def _writeVcdSigs(f, hierarchy, tracelists):
         # all memories are flattened and renamed.
         if tracelists:
             for n in memdict.keys():
+                print("$scope module {} $end" .format(n), file=f)
                 memindex = 0
                 for s in memdict[n].mem:
                     sval = _getSval(s)
@@ -197,6 +198,7 @@ def _writeVcdSigs(f, hierarchy, tracelists):
                     else:
                         print("$var real 1 %s %s(%i) $end" % (s._code, n, memindex), file=f)
                     memindex += 1
+                print("$upscope $end", file=f)
     for i in range(curlevel):
         print("$upscope $end", file=f)
     print(file=f)


### PR DESCRIPTION
added scope-module// upscope around mem signals to properly display as a _collapsible_ group with the [Impulse plugin] (http://toem.de/) for Eclipse. This should also apply to GTKwave, but it (at least my freshly installed Windows version v3.3.65) doesn't seem to do anything with it. 