### PR TITLE
assign statement (constwires) support litterals larger than 32 bits

### DIFF
--- a/myhdl/conversion/_toVerilog.py
+++ b/myhdl/conversion/_toVerilog.py
@@ -324,7 +324,9 @@ def _writeSigDecls(f, intf, siglist, memlist):
             c = int(s.val)
         else:
             raise ToVerilogError("Unexpected type for constant signal", s._name)
-        print("assign %s = %s;" % (s._name, c), file=f)
+        c_len = s._nrbits
+        c_str = "%s"%c
+        print("assign %s = %s'd%s;" % (s._name, c_len,  c_str), file=f)
     print(file=f)
     # shadow signal assignments
     for s in siglist:


### PR DESCRIPTION
The size of literal integer was not specified in the assign statement. 