### PR TITLE
add test for issue 134

### DIFF
--- a/myhdl/test/bugs/test_issue134.py
+++ b/myhdl/test/bugs/test_issue134.py
@@ -6,7 +6,7 @@ function is called multiple times, this causes name collisions """
 from __future__ import absolute_import
 import pytest
 from myhdl import *
-from myhdl.conversion import verify
+from myhdl.conversion import analyze
 
 class AB:
     def __init__(self):
@@ -28,4 +28,4 @@ def issue_134(ab_in, ab_out):
 @pytest.mark.xfail
 def test_issue_134():
     """ check for port name collision"""
-    assert verify(issue_134, AB(), AB()) == 0
+    assert analyze(issue_134, AB(), AB()) == 0

--- a/myhdl/test/bugs/test_issue134.py
+++ b/myhdl/test/bugs/test_issue134.py
@@ -4,6 +4,7 @@ can get renamed to the name of the argument. When the
 function is called multiple times, this causes name collisions """
 
 from __future__ import absolute_import
+import pytest
 from myhdl import *
 from myhdl.conversion import verify
 
@@ -18,12 +19,13 @@ def invert(sigin, sigout):
         sigout.next = not sigin
     return foo
 
-def issue_133(ab_in, ab_out):
+def issue_134(ab_in, ab_out):
     """ Instantiate an inverter for each signal """
     inverta = invert(ab_in.a, ab_out.a)
     invertb = invert(ab_in.b, ab_out.b)
     return inverta, invertb
 
-def test_issue_133():
+@pytest.mark.xfail
+def test_issue_134():
     """ check for port name collision"""
-    assert verify(issue_133, AB(), AB()) == 0
+    assert verify(issue_134, AB(), AB()) == 0

--- a/myhdl/test/bugs/test_issue134.py
+++ b/myhdl/test/bugs/test_issue134.py
@@ -1,0 +1,29 @@
+"""
+When an interface signal gets passed into a function, it
+can get renamed to the name of the argument. When the
+function is called multiple times, this causes name collisions """
+
+from __future__ import absolute_import
+from myhdl import *
+from myhdl.conversion import verify
+
+class AB:
+    def __init__(self):
+        self.a = Signal(bool(False))
+        self.b = Signal(bool(False))
+
+def invert(sigin, sigout):
+    @always_comb
+    def foo():
+        sigout.next = not sigin
+    return foo
+
+def issue_133(ab_in, ab_out):
+    """ Instantiate an inverter for each signal """
+    inverta = invert(ab_in.a, ab_out.a)
+    invertb = invert(ab_in.b, ab_out.b)
+    return inverta, invertb
+
+def test_issue_133():
+    """ check for port name collision"""
+    assert verify(issue_133, AB(), AB()) == 0


### PR DESCRIPTION
checks for port name collision when a function names two signals with the same name