### PR TITLE
fix bug in test_custom tests

### DIFF
--- a/myhdl/test/conversion/toVHDL/test_custom.py
+++ b/myhdl/test/conversion/toVHDL/test_custom.py
@@ -74,10 +74,10 @@ def inc(count, enable, clock, reset, n):
     __vhdl__ = \
 """
 process (%(clock)s, %(reset)s) begin
-    if (reset = '0') then
+    if (%(reset)s = '0') then
         %(count)s <= (others => '0');
     elsif rising_edge(%(clock)s) then
-        if (enable = '1') then
+        if (%(enable)s = '1') then
             %(count)s <= (%(count)s + 1) mod %(n)s;
         end if;
     end if;
@@ -104,11 +104,11 @@ def incErr(count, enable, clock, reset, n):
     __vhdl__ = \
 """
 always @(posedge %(clock)s, negedge %(reset)s) begin
-    if (reset == 0) begin
+    if (%(reset)s == 0) begin
         %(count)s <= 0;
     end
     else begin
-        if (enable) begin
+        if (%(enable)s) begin
             %(count)s <= (%(countq)s + 1) %% %(n)s;
         end
     end
@@ -151,10 +151,10 @@ def inc_seq(count, nextCount, enable, clock, reset):
     __vhdl__ = \
 """
 process (%(clock)s, %(reset)s) begin
-    if (reset = '0') then
+    if (%(reset)s = '0') then
         %(count)s <= (others => '0');
     elsif rising_edge(%(clock)s) then
-        if (enable = '1') then
+        if (%(enable)s = '1') then
             %(count)s <= %(nextCount)s;
         end if;
     end if;

--- a/myhdl/test/conversion/toVHDL/test_newcustom.py
+++ b/myhdl/test/conversion/toVHDL/test_newcustom.py
@@ -74,10 +74,10 @@ def inc(count, enable, clock, reset, n):
     inc.vhdl_code = \
 """
 process ($clock, $reset) begin
-    if (reset = '0') then
+    if ($reset = '0') then
         $count <= (others => '0');
     elsif rising_edge($clock) then
-        if (enable = '1') then
+        if ($enable = '1') then
             $count <= ($count + 1) mod $n;
         end if;
     end if;
@@ -104,11 +104,11 @@ def incErr(count, enable, clock, reset, n):
     incErr.vhdl_code = \
 """
 always @(posedge $clock, negedge $reset) begin
-    if (reset == 0) begin
+    if ($reset == 0) begin
         $count <= 0;
     end
     else begin
-        if (enable) begin
+        if ($enable) begin
             $count <= ($countq + 1) %% $n;
         end
     end
@@ -151,10 +151,10 @@ def inc_seq(count, nextCount, enable, clock, reset):
     inc_seq.vhdl_code = \
 """
 process ($clock, $reset) begin
-    if (reset = '0') then
+    if ($reset = '0') then
         $count <= (others => '0');
     elsif rising_edge($clock) then
-        if (enable = '1') then
+        if ($enable = '1') then
             $count <= $nextCount;
         end if;
     end if;


### PR DESCRIPTION
all signals in custom VHDL should have the signal names prefixed with a dollar.