### PR TITLE
Add 'directory' attribute to traceSignals.

### DIFF
--- a/doc/source/manual/reference.rst
+++ b/doc/source/manual/reference.rst
@@ -85,8 +85,13 @@ Waveform tracing
       This attribute is used to overwrite the default top-level instance name and the
       basename of the VCD output filename.
 
+   .. attribute:: directory
+
+      This attribute is used to set the directory to which VCD files are written. By
+      default, the current working directory is used.
+
    .. attribute:: timescale
-   
+
       This attribute is used to set the timescale corresponding to unit steps,
       according to the VCD format. The assigned value should be a string.
       The default timescale is "1ns".

--- a/myhdl/_traceSignals.py
+++ b/myhdl/_traceSignals.py
@@ -50,12 +50,14 @@ _error.MultipleTraces = "Cannot trace multiple instances simultaneously"
 class _TraceSignalsClass(object):
 
     __slot__ = ("name",
+                "directory",
                 "timescale",
                 "tracelists"
                 )
 
     def __init__(self):
         self.name = None
+        self.directory = None
         self.timescale = "1ns"
         self.tracelists = True
 
@@ -82,8 +84,14 @@ class _TraceSignalsClass(object):
                 name = str(self.name)
             if name is None:
                 raise TraceSignalsError(_error.TopLevelName)
+
+            if self.directory is None:
+                directory = ''
+            else:
+                directory = self.directory
+
             h = _HierExtr(name, dut, *args, **kwargs)
-            vcdpath = name + ".vcd"
+            vcdpath = os.path.join(directory, name + ".vcd")
             if path.exists(vcdpath):
                 backup = vcdpath + '.' + str(path.getmtime(vcdpath))
                 shutil.copyfile(vcdpath, backup)
@@ -111,7 +119,7 @@ def _genNameCode():
     while 1:
         yield _namecode(n)
         n += 1
-        
+
 def _namecode(n):
     q, r = divmod(n, _mod)
     code = _codechars[r]
@@ -175,7 +183,7 @@ def _writeVcdSigs(f, hierarchy, tracelists):
             else:
                 print("$var real 1 %s %s $end" % (s._code, n), file=f)
         # Memory dump by Frederik Teichert, http://teichert-ing.de, date: 2011.03.28
-        # The Value Change Dump standard doesn't support multidimensional arrays so 
+        # The Value Change Dump standard doesn't support multidimensional arrays so
         # all memories are flattened and renamed.
         if tracelists:
             for n in memdict.keys():
@@ -207,16 +215,3 @@ def _writeVcdSigs(f, hierarchy, tracelists):
     for s in siglist:
         s._printVcd() # initial value
     print("$end", file=f)
-            
-            
-        
-        
-
-
-    
-    
-
-            
-        
-    
-    

--- a/myhdl/test/core/test_traceSignals.py
+++ b/myhdl/test/core/test_traceSignals.py
@@ -173,3 +173,16 @@ class TestTraceSigs:
         assert path.exists(pbak)
         assert path.getsize(pbak) == size
         assert path.getsize(p) < size
+
+    def testSetDirectory(self, vcd_dir):
+        traceSignals.directory = 'some_vcd_dir'
+        os.mkdir(path.join(str(vcd_dir), traceSignals.directory))
+        pdut = "%s.vcd" % top.__name__
+        psub = "%s.vcd" % fun.__name__
+        pdutd = path.join(traceSignals.directory, "%s.vcd" % top.__name__)
+        psubd = path.join(traceSignals.directory, "%s.vcd" % fun.__name__)
+        dut = traceSignals(top)
+        assert not path.exists(pdut)
+        assert not path.exists(psub)
+        assert path.exists(pdutd)
+        assert not path.exists(psubd)


### PR DESCRIPTION
This change does exactly what the 'directory' attribute for toVerilog and toVHDL
do. It allows the user to specify the output directory for VCD files.

This commit includes the source change, documentation change, and a py.test
change to test the functionality.