### PR TITLE
Add 'filename' attribute to traceSignals

### DIFF
--- a/doc/source/manual/reference.rst
+++ b/doc/source/manual/reference.rst
@@ -90,6 +90,11 @@ Waveform tracing
       This attribute is used to set the directory to which VCD files are written. By
       default, the current working directory is used.
 
+   .. attribute:: filename
+
+      This attribute is used to set the filename to which VCD files are written. By
+      default, the name attribbute is used.
+
    .. attribute:: timescale
 
       This attribute is used to set the timescale corresponding to unit steps,

--- a/myhdl/_traceSignals.py
+++ b/myhdl/_traceSignals.py
@@ -50,6 +50,7 @@ class _TraceSignalsClass(object):
 
     __slot__ = ("name",
                 "directory",
+                "filename",
                 "timescale",
                 "tracelists"
                 )
@@ -57,6 +58,7 @@ class _TraceSignalsClass(object):
     def __init__(self):
         self.name = None
         self.directory = None
+        self.filename = None
         self.timescale = "1ns"
         self.tracelists = True
 
@@ -89,8 +91,13 @@ class _TraceSignalsClass(object):
             else:
                 directory = self.directory
 
+            if self.filename is None:
+                filename = self.name
+            else
+                filename = self.filename
+
             h = _HierExtr(name, dut, *args, **kwargs)
-            vcdpath = os.path.join(directory, name + ".vcd")
+            vcdpath = os.path.join(directory, filename + ".vcd")
             if path.exists(vcdpath):
                 backup = vcdpath + '.' + str(path.getmtime(vcdpath))
                 shutil.copyfile(vcdpath, backup)

--- a/myhdl/_traceSignals.py
+++ b/myhdl/_traceSignals.py
@@ -93,7 +93,7 @@ class _TraceSignalsClass(object):
 
             if self.filename is None:
                 filename = self.name
-            else
+            else:
                 filename = self.filename
 
             h = _HierExtr(name, dut, *args, **kwargs)

--- a/myhdl/_traceSignals.py
+++ b/myhdl/_traceSignals.py
@@ -97,7 +97,7 @@ class _TraceSignalsClass(object):
                 filename = str(self.filename)
 
             h = _HierExtr(name, dut, *args, **kwargs)
-            vcdpath = os.path.join(directory, name + ".vcd")
+            vcdpath = os.path.join(directory, filename + ".vcd")
             if path.exists(vcdpath):
                 backup = vcdpath + '.' + str(path.getmtime(vcdpath))
                 shutil.copyfile(vcdpath, backup)

--- a/myhdl/_traceSignals.py
+++ b/myhdl/_traceSignals.py
@@ -92,12 +92,12 @@ class _TraceSignalsClass(object):
                 directory = self.directory
 
             if self.filename is None:
-                filename = self.name
+                filename = name
             else:
-                filename = self.filename
+                filename = str(self.filename)
 
             h = _HierExtr(name, dut, *args, **kwargs)
-            vcdpath = os.path.join(directory, filename + ".vcd")
+            vcdpath = os.path.join(directory, name + ".vcd")
             if path.exists(vcdpath):
                 backup = vcdpath + '.' + str(path.getmtime(vcdpath))
                 shutil.copyfile(vcdpath, backup)


### PR DESCRIPTION
Additional to the directory attribute, I'd like to have a filename attribute. The reason is, when I run tests, the resulting vcd files are all named the same, that will result in the unreadable date suffix. 
The reason for not changing the name attribute is, that myhdl uses it to extract the hierachy and will rename it in the vcd file, which is ugly. 