### PR TITLE
updated doc for the new public method sim.quit()

### DIFF
--- a/doc/source/manual/reference.rst
+++ b/doc/source/manual/reference.rst
@@ -41,6 +41,14 @@ A :class:`Simulation` object has the following method:
    Run the simulation forever (by default) or for a specified duration.
 
 
+.. method:: Simulation.quit()
+
+   Quit the simulation after it has run for a specified duration. The method should
+   be called (the simulation instance must be quit) before another simulation
+   instance is created. The method is called by default when the simulation is run
+   forever.
+
+
 .. _ref-simsupport:
 
 Simulation support functions

--- a/example/cookbook/dff/dff.py
+++ b/example/cookbook/dff/dff.py
@@ -33,6 +33,7 @@ def simulate(timesteps):
     tb = traceSignals(test_dff)
     sim = Simulation(tb)
     sim.run(timesteps)
+    sim.quit()
 
 simulate(2000)
 

--- a/example/cookbook/dffa/dffa.py
+++ b/example/cookbook/dffa/dffa.py
@@ -44,6 +44,7 @@ def simulate(timesteps):
     tb = traceSignals(test_dffa)
     sim = Simulation(tb)
     sim.run(timesteps)
+    sim.quit()
 
 simulate(20000)
 

--- a/example/cookbook/latch/latch.py
+++ b/example/cookbook/latch/latch.py
@@ -33,6 +33,7 @@ def simulate(timesteps):
     tb = traceSignals(test_latch)
     sim = Simulation(tb)
     sim.run(timesteps)
+    sim.quit()
 
 simulate(20000)
 


### PR DESCRIPTION
I have added the line sim.quit() at places where there was a chance of creating more than one simulation instance.
At places where the simulation was run for a specified duration, but only one instance of simulation was created in the program I didn't add sim.quit() line as the program was anyways going to get terminated.