### PR TITLE
Small fix to enable self.name be used in exceptions in _verifySubs in _Block

### DIFF
--- a/myhdl/_block.py
+++ b/myhdl/_block.py
@@ -107,11 +107,12 @@ class _Block(object):
         self.symdict = None
         self.sigdict = {}
         self.memdict = {}
+        self.name = self.__name__ = func.__name__ + '_' + str(calls - 1)
+
         # flatten, but keep BlockInstance objects
         self.subs = _flatten(func(*args, **kwargs))
         self._verifySubs()
         self._updateNamespaces()
-        self.name = self.__name__ = func.__name__ + '_' + str(calls - 1)
         self.verilog_code = self.vhdl_code = None
         self.sim = None
         if hasattr(deco, 'verilog_code'):

--- a/myhdl/_block.py
+++ b/myhdl/_block.py
@@ -35,7 +35,7 @@ from myhdl._Signal import _Signal, _isListOfSigs
 
 class _error:
     pass
-_error.ArgType = "A block should return block or instantiator objects"
+_error.ArgType = "%s: A block should return block or instantiator objects"
 _error.InstanceError = "%s: subblock %s should be encapsulated in a block decorator"
 
 
@@ -126,7 +126,7 @@ class _Block(object):
     def _verifySubs(self):
         for inst in self.subs:
             if not isinstance(inst, (_Block, _Instantiator, Cosimulation)):
-                raise BlockError(_error.ArgType)
+                raise BlockError(_error.ArgType % (self.name,))
             if isinstance(inst, (_Block, _Instantiator)):
                 if not inst.modctxt:
                     raise BlockError(_error.InstanceError % (self.name, inst.callername))


### PR DESCRIPTION
Prior to this patch, `_verifySubs` is called before `self.name` is assigned, but in some exceptions `_verifySubs` uses `self.name`, so we get a fairly unhelpful attribute error about missing `name` rather than useful information about the actual error.