### PR TITLE
[WIP] Improved block decorator

### DIFF
--- a/myhdl/_block.py
+++ b/myhdl/_block.py
@@ -107,11 +107,12 @@ class _Block(object):
         self.symdict = None
         self.sigdict = {}
         self.memdict = {}
+        self.name = self.__name__ = func.__name__ + '_' + str(calls - 1)
+
         # flatten, but keep BlockInstance objects
         self.subs = _flatten(func(*args, **kwargs))
         self._verifySubs()
         self._updateNamespaces()
-        self.name = self.__name__ = func.__name__ + '_' + str(calls - 1)
         self.verilog_code = self.vhdl_code = None
         self.sim = None
         if hasattr(deco, 'verilog_code'):

--- a/myhdl/_block.py
+++ b/myhdl/_block.py
@@ -35,7 +35,7 @@ from myhdl._Signal import _Signal, _isListOfSigs
 
 class _error:
     pass
-_error.ArgType = "A block should return block or instantiator objects"
+_error.ArgType = "%s: A block should return block or instantiator objects"
 _error.InstanceError = "%s: subblock %s should be encapsulated in a block decorator"
 
 
@@ -126,7 +126,7 @@ class _Block(object):
     def _verifySubs(self):
         for inst in self.subs:
             if not isinstance(inst, (_Block, _Instantiator, Cosimulation)):
-                raise BlockError(_error.ArgType)
+                raise BlockError(_error.ArgType % (self.name,))
             if isinstance(inst, (_Block, _Instantiator)):
                 if not inst.modctxt:
                     raise BlockError(_error.InstanceError % (self.name, inst.callername))


### PR DESCRIPTION
Consider the following code:

    from myhdl import *

    @block
    def drive(clock, a, b):
        @always(clock.posedge)
        def driver():
            a.next = 2
            b.next = 2
                
        return driver

    @block
    def clock_gen(clk):

        @always(delay(10))
        def driveClk():
            clk.next = not clk

        return driveClk

    class Gah(object):

        def __init__(self, clock):
            self.clock = clock

        @block
        def foo(self, a, b):
            driver = drive(self.clock, a, b)
            clock_driver = clock_gen(self.clock)
            return [driver, clock_driver]

    clock = Signal(False)

    a,b = Signal(intbv(0, min=-10, max=10)), Signal(intbv(0, min=-10, max=10))

    gah = Gah(clock)
    gah.foo(a, b).convert(hdl='VHDL')

As currently implemented in master, the block decorator will not be able to handle the extra `self` argument to the top level conversion function `gah.foo`. This is due to the differences in the way instance methods should be handled compared to normal functions by decorators.

The result of running the above is an inclusion of an extra interface port from `clock`, which it then complains about being read internally. Clearly `clock` should not feature in the interface at all. This arises because `self` is treated as an object to inspect as being part of the interface, so its name space is checked for Signals (AFAICT, `self` is assumed to be an interface object).

This issue of decorators and their subtleties discussed at some length in the following blog posts:
http://blog.dscpl.com.au/2014/01/how-you-implemented-your-python.html
http://blog.dscpl.com.au/2014/01/the-interaction-between-decorators-and.html

This PR fixes the problem with the approach highlighted in the second post. 

It is a WIP because it doesn't complete the decorator to the case described in the second post using transparent proxies (which may be overkill), and also because one `conversion.test_hdlobjnotself` now fails. The test failure looks like it is directly related to this issue, so more advice is needed (I haven't yet looked at the test failure with a view to debugging).

More useful decorator related posts from the above author can be found here:
http://blog.dscpl.com.au/p/decorators-and-monkey-patching.html